### PR TITLE
Swipe distance ratio customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ SwipeActionView is a swipe-able view, which allows users to perform actions by s
 - [Ripple animations](#ripple-animations)
 - [Click listeners](#click-listeners)
 - [Animate from code](#code-animation)
+- [Activation distance](#activation-distance)
 - [Attributes](#attr)
   - [sav_rippleTakesPadding](#attr-rippleTakesPadding)
   - [sav_swipeLeftRippleColor](#attr-swipeLeftRippleColor)
@@ -246,6 +247,9 @@ swipeView.animateToOriginalPosition(500)
 // Instantly animate the view to its original position
 swipeView.animateToOriginalPosition()
 ```
+
+# <a id="activation-distance">Activation distance</a>
+You can customize the siwpe distance required for callbacks to be executed by using the `activationDistanceRatio` property. It receives a value in range from `0.0f` to `1.0f`, which means the percentage of background view that has to be revealed. For example if set to `0.5f` the user has to reveal at least half of the background view before releasing their finger in order for the gesture callbacks to be executed.
 
 # <a id="attr">Attributes</a>
 

--- a/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
+++ b/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
@@ -95,12 +95,6 @@ class SwipeActionView : FrameLayout {
     private val handler = PressTimeoutHandler(this)
 
     /**
-     * The percentage of the [maxLeftSwipeDistance] or [maxRightSwipeDistance] after which swipe
-     * callbacks can can be executed.
-     */
-    private var minActivationDistanceRatio = 0.8f
-
-    /**
      * Ripple displayed after performing swipe left gesture.
      */
     private val leftSwipeRipple = SwipeRippleDrawable()
@@ -198,12 +192,14 @@ class SwipeActionView : FrameLayout {
     /**
      * The minimum distance required to execute swipe callbacks when swiping to the left side.
      */
-    private var minLeftActivationDistance = 0f
+    private val minLeftActivationDistance: Float
+        get() = activationDistanceRatio * maxLeftSwipeDistance
 
     /**
      * The minimum distance required to execute swipe callbacks when swiping to the right side.
      */
-    private var minRightActivationDistance = 0f
+    private val minRightActivationDistance: Float
+        get() = activationDistanceRatio * maxRightSwipeDistance
 
     /**
      * Determines whether ripple drawables should have padding.
@@ -229,6 +225,18 @@ class SwipeActionView : FrameLayout {
      * The callback to be invoked when this view is clicked and held.
      */
     private var onLongClickListener: OnLongClickListener? = null
+
+    /**
+     * The percentage of the swipe distance (width of the revealed view) after which swipe
+     * callbacks should be executed. (Defaults to 80%)
+     */
+    var activationDistanceRatio = 0.8f
+        set(newRatio) {
+            if (newRatio < 0f || newRatio > 1f) {
+                throw IllegalArgumentException("Activation distance ratio must be a value in range <0.0f, 1.0f>. Provided: $newRatio")
+            }
+            field = newRatio
+        }
 
     /**
      * Listener for the swipe left and right gestures.
@@ -347,15 +355,13 @@ class SwipeActionView : FrameLayout {
         leftSwipeRipple.maxRadius = maxRadius
         rightSwipeRipple.maxRadius = maxRadius
 
-        leftSwipeView?.let {
-            maxLeftSwipeDistance = it.totalWidth.toFloat() - container.marginEnd
-            minLeftActivationDistance = minActivationDistanceRatio * maxLeftSwipeDistance
-        }
+        maxLeftSwipeDistance = leftSwipeView?.let {
+            it.totalWidth.toFloat() - container.marginEnd
+        } ?: 0f
 
-        rightSwipeView?.let {
-            maxRightSwipeDistance = it.totalWidth.toFloat() - container.marginStart
-            minRightActivationDistance = minActivationDistanceRatio * maxRightSwipeDistance
-        }
+        maxRightSwipeDistance = rightSwipeView?.let {
+            it.totalWidth.toFloat() - container.marginStart
+        } ?: 0f
 
         if (isInEditMode) {
             when (previewBackground) {
@@ -439,14 +445,6 @@ class SwipeActionView : FrameLayout {
         val view = getViewForDirection(direction)
             ?: throw IllegalArgumentException("View for the specified direction doesn't exist.")
         view.visibility = if (enabled) View.VISIBLE else View.GONE
-    }
-    
-     /**
-     * Set the minimum ratio for swiping (default 0.8f)
-     * @param ratio
-     * **/
-    fun setSwipeRatio(ratio: Float) {
-        minActivationDistanceRatio = ratio
     }
 
     @JvmOverloads
@@ -549,7 +547,9 @@ class SwipeActionView : FrameLayout {
             }
 
             MotionEvent.ACTION_UP -> {
-                if (isClickable && isTouchValid && !dragging && !inLongPress && !hasMovedVertically(e)) {
+                if (isClickable && isTouchValid && !dragging && !inLongPress
+                    && !hasMovedVertically(e)
+                ) {
                     startPress(e.x, e.y)
                     performClick()
                 }

--- a/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
+++ b/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
@@ -98,7 +98,7 @@ class SwipeActionView : FrameLayout {
      * The percentage of the [maxLeftSwipeDistance] or [maxRightSwipeDistance] after which swipe
      * callbacks can can be executed.
      */
-    private val minActivationDistanceRatio = 0.8f
+    private var minActivationDistanceRatio = 0.8f
 
     /**
      * Ripple displayed after performing swipe left gesture.
@@ -439,6 +439,14 @@ class SwipeActionView : FrameLayout {
         val view = getViewForDirection(direction)
             ?: throw IllegalArgumentException("View for the specified direction doesn't exist.")
         view.visibility = if (enabled) View.VISIBLE else View.GONE
+    }
+    
+     /**
+     * Set the minimum ratio for swiping (default 0.8f)
+     * @param ratio
+     * **/
+    fun setSwipeRatio(ratio: Float) {
+        minActivationDistanceRatio = ratio
     }
 
     @JvmOverloads

--- a/sample/src/main/java/me/thanel/swipeactionview/sample/MainActivity.java
+++ b/sample/src/main/java/me/thanel/swipeactionview/sample/MainActivity.java
@@ -56,6 +56,7 @@ public class MainActivity extends AppCompatActivity {
         swipeLeft.setSwipeGestureListener(swipeGestureListener);
 
         SwipeActionView swipeBoth = findViewById(R.id.swipe_both);
+        swipeBoth.setActivationDistanceRatio(0.5f);
         swipeBoth.setSwipeGestureListener(swipeGestureListener);
 
         SwipeActionView swipeWithRipples = findViewById(R.id.swipe_with_ripples);
@@ -93,9 +94,11 @@ public class MainActivity extends AppCompatActivity {
 
     public void swipeLeft(View view) {
         swipeCustomLayout.animateInDirection(SwipeDirection.Left, true);
+        swipeCustomLayout.setActivationDistanceRatio(0.2f);
     }
 
     public void swipeRight(View view) {
         swipeCustomLayout.animateInDirection(SwipeDirection.Right, true);
+        swipeCustomLayout.setActivationDistanceRatio(0.8f);
     }
 }


### PR DESCRIPTION
Based on a425bfddc60ea10ed3f8a971bcdcc49d7b80761e from #16, this pull request adds a way to customize swipe distance ratio that is used to decide how far the user has to swipe before gesture callbacks can be executed. The default value stays at **80%**.

# Example

```kt
// Gesture callbacks will be executed when user reveals 50% of the background view and releases the finger
swipeView.activationDistanceRatio = 0.5f
```