### PR TITLE
Allow child views to intercept touch events

### DIFF
--- a/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
+++ b/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
@@ -518,10 +518,6 @@ class SwipeActionView : FrameLayout {
                 prepareDrag(e)
             }
 
-            MotionEvent.ACTION_MOVE -> {
-                return handleMoveEvent(e)
-            }
-
             MotionEvent.ACTION_UP,
             MotionEvent.ACTION_CANCEL -> {
                 cancelDrag()
@@ -529,8 +525,7 @@ class SwipeActionView : FrameLayout {
             }
         }
 
-        // In most cases we don't want to handle touch events alone. We give child views a chance to
-        // intercept them.
+        // Give child views a chance to intercept touch events before this view.
         return false
     }
 
@@ -539,6 +534,12 @@ class SwipeActionView : FrameLayout {
             MotionEvent.ACTION_DOWN -> {
                 prepareDrag(e)
                 prepareMessages(e)
+
+                // Stop the animator to allow "catching" of view.
+                // By "catching" I mean the possibility for user to click on the view and continue swiping
+                // from the position at which it was when starting new swipe.
+                animator.cancel()
+
                 return true
             }
 
@@ -611,11 +612,6 @@ class SwipeActionView : FrameLayout {
         lastX = e.rawX
         initialRawX = e.rawX
         initialRawY = e.rawY
-
-        // Stop the animator to allow "catching" of view.
-        // By "catching" I mean the possibility for user to click on the view and continue swiping
-        // from the position at which it was when starting new swipe.
-        animator.cancel()
 
         handler.removeOurMessages()
     }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -212,5 +212,7 @@
                 app:cardElevation="10dp" />
 
         </me.thanel.swipeactionview.SwipeActionView>
+
+        <include layout="@layout/item_with_horizontal_scroll_view" />
     </LinearLayout>
 </ScrollView>

--- a/sample/src/main/res/layout/item_with_horizontal_scroll_view.xml
+++ b/sample/src/main/res/layout/item_with_horizontal_scroll_view.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<me.thanel.swipeactionview.SwipeActionView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/SwipeItem"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:sav_swipeLeftRippleColor="@color/colorAccent"
+    app:sav_swipeRightRippleColor="@color/colorPrimary"
+    tools:ignore="ContentDescription,HardcodedText">
+
+    <ImageView style="@style/Icon" />
+
+    <ImageView
+        style="@style/Icon"
+        android:layout_gravity="end|center_vertical" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/white"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="This view contains a horizontally scrolling child view below which will take preference in intercepting swipe events." />
+
+        <HorizontalScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="16dp"
+                android:text="This is a text view located in a horizontally scrolling container. When swiping here SwipeActionView won't activate." />
+
+        </HorizontalScrollView>
+
+    </LinearLayout>
+
+</me.thanel.swipeactionview.SwipeActionView>


### PR DESCRIPTION
This pull request fixes the behavior of touch interception by allowing any child views of `SwipeActionView` to intercept touch events and perform own actions. By doing so it is now possible to scroll inside of horizontally scrolling views that are added as children of `SwipeActionView`.

![C8qM9Yxeib](https://user-images.githubusercontent.com/5156340/76683333-9d681300-6603-11ea-8256-a72062848070.gif)

Closes #22 