### PR TITLE
Implement MultiSwipeActionView for multiple actions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.0'
+    ext.kotlin_version = '1.9.10'
     repositories {
         mavenCentral()
-        jcenter()
         google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:8.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }
@@ -16,7 +15,6 @@ buildscript {
 allprojects {
     repositories {
         mavenCentral()
-        jcenter()
         google()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Mar 07 19:06:55 CET 2019
+#Wed Oct 04 09:22:37 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,57 +1,66 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'maven-publish'
-
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'maven-publish'
+}
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
-
     defaultConfig {
+        namespace = "me.thanel.swipeactionview"
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 33
+        compileSdk 33
     }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
-}
 
-publishing {
-    publications {
-        release(MavenPublication) {
-            artifact(bundleReleaseAar)
-            artifact sourcesJar
-            artifact javadocJar
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
 
-            groupId = 'com.github.Tunous'
-            artifactId = 'SwipeActionView'
-            version = '1.4.0-SNAPSHOT'
-        }
+    kotlinOptions {
+        jvmTarget = "17"
     }
 }
 
+/*
+project.afterEvaluate {
+    publishing {
+        publications {
+            aar(MavenPublication) {
+                groupId = 'com.github.Tunous'
+                artifactId = 'SwipeActionView'
+                version = '1.4.0-SNAPSHOT'
+
+                artifact bundleReleaseAar
+                artifact sourcesJar
+                artifact javadocJar
+            }
+        }
+    }
+}*/
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
+
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
+    archiveClassifier = 'sources'
 }
 
 task javadoc(type: Javadoc) {
     failOnError false
     source = android.sourceSets.main.java.sourceFiles
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    classpath += configurations.compile
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
+    archiveClassifier = 'javadoc'
     from javadoc.destinationDir
 }
-
-

--- a/library/src/main/kotlin/me/thanel/swipeactionview/MultiSwipeActionView.kt
+++ b/library/src/main/kotlin/me/thanel/swipeactionview/MultiSwipeActionView.kt
@@ -1,0 +1,15 @@
+package me.thanel.swipeactionview
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.LinearLayout
+
+class MultiSwipeActionView : LinearLayout {
+    constructor(context: Context?) : super(context)
+    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(
+        context,
+        attrs,
+        defStyleAttr
+    )
+}

--- a/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
+++ b/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
@@ -195,7 +195,7 @@ class SwipeActionView : FrameLayout {
      * Only used for MultiSwipeActionView
      * Should be coordinated with resistance-multiplier
      */
-    private val distanceFromCenterpoint = 14
+    private val distanceFromCenterpoint = 8
 
     /**
      * The minimum distance required to execute swipe callbacks when swiping to the left side.
@@ -814,7 +814,7 @@ class SwipeActionView : FrameLayout {
 
         var resistance = dragResistance
         val normalizedTranslation = container.translationX.absoluteValue
-        val resistanceMulitplier = 8
+        val resistanceMulitplier = 4
 
         //swiping right
         if(container.translationX>0){

--- a/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
+++ b/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
@@ -921,8 +921,7 @@ class SwipeActionView : FrameLayout {
             leftSwipeRipple.restart()
         }
 
-        var targetTranslationX = if (swipedRight) maxRightSwipeDistance else -maxLeftSwipeDistance
-        animateContainer(targetTranslationX, swipeAnimationDuration) {
+        animateContainer(getTargetTranslationX(swipedRight, isHalfwaySwipe), swipeAnimationDuration) {
             val shouldFinish = if (swipedRight) {
                 if(isHalfwaySwipe) {
                     swipeGestureListener?.onSwipedHalfwayRight(this)
@@ -1036,6 +1035,26 @@ class SwipeActionView : FrameLayout {
     private fun getMaxSwipeDistance(delta: Float) = when {
         delta < 0 -> maxLeftSwipeDistance
         else -> maxRightSwipeDistance
+    }
+
+    /**
+     * Get the translation distance for the animate container
+     *
+     * @param swipedRight whether the user swiped right or left (true for right, false for left)
+     * @param isHalfwaySwipe whether the user swiped ony the first item
+     *
+     * @return Translation Value
+     */
+    private fun getTargetTranslationX(swipedRight: Boolean, isHalfwaySwipe: Boolean): Float {
+        return if(isHalfwaySwipe) {
+            return if (swipedRight) {
+                ((rightSwipeView as MultiSwipeActionView).getChildAt(0)?.width ?: maxRightSwipeDistance).toFloat()
+            } else {
+                ((leftSwipeView as MultiSwipeActionView).getChildAt(0)?.width ?: -maxLeftSwipeDistance).toFloat()
+            }
+        } else {
+            if (swipedRight) maxRightSwipeDistance else -maxLeftSwipeDistance
+        }
     }
 
     /**

--- a/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
+++ b/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
@@ -945,7 +945,6 @@ class SwipeActionView : FrameLayout {
                     } else {
                         swipeGestureListener?.onSwipeLeftComplete(this)
                     }
-                    swipeGestureListener?.onSwipeLeftComplete(this)
                 }
             }
         }

--- a/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
+++ b/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
@@ -1050,7 +1050,7 @@ class SwipeActionView : FrameLayout {
             return if (swipedRight) {
                 ((rightSwipeView as MultiSwipeActionView).getChildAt(0)?.width ?: maxRightSwipeDistance).toFloat()
             } else {
-                ((leftSwipeView as MultiSwipeActionView).getChildAt(0)?.width ?: -maxLeftSwipeDistance).toFloat()
+                -((leftSwipeView as MultiSwipeActionView).getChildAt(0)?.width ?: maxLeftSwipeDistance).toFloat()
             }
         } else {
             if (swipedRight) maxRightSwipeDistance else -maxLeftSwipeDistance

--- a/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
+++ b/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
@@ -920,20 +920,21 @@ class SwipeActionView : FrameLayout {
         } else {
             leftSwipeRipple.restart()
         }
-        if(isHalfwaySwipe) {
-            if (swipedRight) {
-                swipeGestureListener?.onSwipedHalfwayRight(this)
-            } else {
-                swipeGestureListener?.onSwipedHalfwayLeft(this)
-            }
-        }
 
         var targetTranslationX = if (swipedRight) maxRightSwipeDistance else -maxLeftSwipeDistance
         animateContainer(targetTranslationX, swipeAnimationDuration) {
             val shouldFinish = if (swipedRight) {
-                swipeGestureListener?.onSwipedRight(this)
+                if(isHalfwaySwipe) {
+                    swipeGestureListener?.onSwipedHalfwayRight(this)
+                } else {
+                    swipeGestureListener?.onSwipedRight(this)
+                }
             } else {
-                swipeGestureListener?.onSwipedLeft(this)
+                if(isHalfwaySwipe) {
+                    swipeGestureListener?.onSwipedHalfwayLeft(this)
+                } else {
+                    swipeGestureListener?.onSwipedLeft(this)
+                }
             }
 
             if (shouldFinish != false) {

--- a/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
+++ b/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
@@ -878,12 +878,10 @@ class SwipeActionView : FrameLayout {
             return
         }
 
-        if(hasSwipedFarEnoughMultiContainerFirstElement(container.translationX)){
-            activate(container.translationX > 0, true)
-        }
-
         if (hasSwipedFarEnough(container.translationX) || swipedFastEnough) {
             activate(container.translationX > 0)
+        } else if (hasSwipedFarEnoughMultiContainerFirstElement(container.translationX)) {
+            activate(container.translationX > 0, true)
         } else {
             animateToOriginalPosition()
         }

--- a/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
+++ b/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
@@ -911,7 +911,7 @@ class SwipeActionView : FrameLayout {
             setFloatValues(targetTranslationX)
             removeAllListeners()
             addListener(object : AnimatorListenerAdapter() {
-                override fun onAnimationEnd(animation: Animator?) {
+                override fun onAnimationEnd(animation: Animator) {
                     onEnd()
                 }
             })

--- a/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
+++ b/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
@@ -785,18 +785,16 @@ class SwipeActionView : FrameLayout {
         //swiping right
         if(swipeDistance>0){
             if (rightSwipeView is MultiSwipeActionView) {
-                val maxSwipe = (rightSwipeView as MultiSwipeActionView).width*0.75
                 val halfway = (rightSwipeView as MultiSwipeActionView).getChildAt(0)?.width ?: 0
-                if(halfway-distanceFromCenterpoint < normalizedTranslation && maxSwipe > normalizedTranslation) {
+                if(halfway-distanceFromCenterpoint < normalizedTranslation) {
                     return true
                 }
             }
         } else {
             if (leftSwipeView is MultiSwipeActionView) {
-                val maxSwipe = (leftSwipeView as MultiSwipeActionView).width*0.75
                 val vg = (leftSwipeView as MultiSwipeActionView)
                 val halfway = vg.getChildAt(vg.childCount-1)?.width ?: 0
-                if(halfway-distanceFromCenterpoint < normalizedTranslation && maxSwipe > normalizedTranslation) {
+                if(halfway-distanceFromCenterpoint < normalizedTranslation) {
                     return true
                 }
             }

--- a/library/src/main/kotlin/me/thanel/swipeactionview/SwipeGestureListener.kt
+++ b/library/src/main/kotlin/me/thanel/swipeactionview/SwipeGestureListener.kt
@@ -48,6 +48,30 @@ interface SwipeGestureListener {
     fun onSwipedRight(swipeActionView: SwipeActionView): Boolean {return true}
 
     /**
+     * Callback method to be invoked when user swipes the [SwipeActionView] to the
+     * left, but only the first element. Requires MultiSwipeActionView as a Container.
+     *
+     * @param swipeActionView The [SwipeActionView] from which this method was invoked.
+     *
+     * @return Whether the container should return to default position. When `false`, then you
+     * should manually call `reset` method to return to default position.
+     * @see SwipeActionView
+     */
+    fun onSwipedHalfwayLeft(swipeActionView: SwipeActionView): Boolean {return true}
+
+    /**
+     * Callback method to be invoked when user swipes the [SwipeActionView] to the
+     * right, but only the first element. Requires MultiSwipeActionView as a Container.
+     *
+     * @param swipeActionView The [SwipeActionView] from which this method was invoked.
+     *
+     * @return Whether the container should return to default position. When `false`, then you
+     * should manually call `reset` method to return to default position.
+     * @see SwipeActionView
+     */
+    fun onSwipedHalfwayRight(swipeActionView: SwipeActionView): Boolean {return true}
+
+    /**
      * Callback method to be invoked when the left swipe is complete.
      * A swipe is considered complete once the view returns back to its original position.
      *

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,15 +1,20 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+    //id 'maven-publish'
+}
+
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         applicationId "me.thanel.swipeactionview.sample"
+        namespace = "me.thanel.swipeactionview.sample"
         minSdkVersion 14
-        targetSdkVersion 28
-        versionCode 2
-        versionName "0.2"
+        targetSdkVersion 33
+        compileSdk 33
+        versionCode 3
+        versionName "0.3"
     }
     buildTypes {
         release {
@@ -20,7 +25,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.cardview:cardview:1.0.0'
 
     implementation project(':library')

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/sample/src/main/java/me/thanel/swipeactionview/sample/MainActivity.java
+++ b/sample/src/main/java/me/thanel/swipeactionview/sample/MainActivity.java
@@ -38,6 +38,18 @@ public class MainActivity extends AppCompatActivity {
 
         SwipeGestureListener swipeGestureListener = new SwipeGestureListener() {
             @Override
+            public boolean onSwipedHalfwayRight(@NonNull SwipeActionView swipeActionView) {
+                showToast(true, true);
+                return false;
+            }
+
+            @Override
+            public boolean onSwipedHalfwayLeft(@NonNull SwipeActionView swipeActionView) {
+                showToast(false, true);
+                return false;
+            }
+
+            @Override
             public void onSwipeRightComplete(SwipeActionView swipeActionView) {
                 // do nothing
             }
@@ -49,13 +61,13 @@ public class MainActivity extends AppCompatActivity {
 
             @Override
             public boolean onSwipedLeft(@NonNull SwipeActionView swipeActionView) {
-                showToast(false);
+                showToast(false, false);
                 return true;
             }
 
             @Override
             public boolean onSwipedRight(@NonNull SwipeActionView swipeActionView) {
-                showToast(true);
+                showToast(true, false);
                 return true;
             }
         };
@@ -77,6 +89,16 @@ public class MainActivity extends AppCompatActivity {
         swipeCardView.setSwipeGestureListener(swipeGestureListener);
 
         SwipeGestureListener delayedSwipeGestureListener = new SwipeGestureListener() {
+            @Override
+            public boolean onSwipedHalfwayRight(@NonNull SwipeActionView swipeActionView) {
+                return true;
+            }
+
+            @Override
+            public boolean onSwipedHalfwayLeft(@NonNull SwipeActionView swipeActionView) {
+                return true;
+            }
+
             @Override
             public void onSwipeRightComplete(SwipeActionView swipeActionView) {
                 //this won't be called since onSwipedRight returns false
@@ -110,6 +132,16 @@ public class MainActivity extends AppCompatActivity {
 
         SwipeGestureListener completeGestureListener = new SwipeGestureListener() {
             @Override
+            public boolean onSwipedHalfwayLeft(@NonNull SwipeActionView swipeActionView) {
+                return true;
+            }
+
+            @Override
+            public boolean onSwipedHalfwayRight(@NonNull SwipeActionView swipeActionView) {
+                return true;
+            }
+
+            @Override
             public void onSwipeRightComplete(SwipeActionView swipeActionView) {
                 Toast.makeText(MainActivity.this, R.string.swipe_right_complete, Toast.LENGTH_SHORT).show();
             }
@@ -136,10 +168,14 @@ public class MainActivity extends AppCompatActivity {
         swipeComplete.setSwipeGestureListener(completeGestureListener);
     }
 
-    private void showToast(Boolean swipedRight) {
+    private void showToast(Boolean swipedRight, Boolean wasHalfway) {
         int resId = swipedRight ? R.string.swiped_right : R.string.swiped_left;
+        String text = getString(resId);
+        if(wasHalfway) {
+            text+= getString(R.string.swiped_halfway);
+        }
 
-        Toast.makeText(this, resId, Toast.LENGTH_SHORT).show();
+        Toast.makeText(this, text, Toast.LENGTH_SHORT).show();
     }
 
     public void swipeLeft(View view) {

--- a/sample/src/main/java/me/thanel/swipeactionview/sample/MainActivity.java
+++ b/sample/src/main/java/me/thanel/swipeactionview/sample/MainActivity.java
@@ -46,7 +46,7 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public boolean onSwipedHalfwayLeft(@NonNull SwipeActionView swipeActionView) {
                 showToast(false, true);
-                return false;
+                return true;
             }
 
             @Override

--- a/sample/src/main/java/me/thanel/swipeactionview/sample/MainActivity.java
+++ b/sample/src/main/java/me/thanel/swipeactionview/sample/MainActivity.java
@@ -40,7 +40,7 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public boolean onSwipedHalfwayRight(@NonNull SwipeActionView swipeActionView) {
                 showToast(true, true);
-                return false;
+                return true;
             }
 
             @Override

--- a/sample/src/main/java/me/thanel/swipeactionview/sample/MainActivity.java
+++ b/sample/src/main/java/me/thanel/swipeactionview/sample/MainActivity.java
@@ -22,6 +22,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+
 import me.thanel.swipeactionview.SwipeActionView;
 import me.thanel.swipeactionview.SwipeDirection;
 import me.thanel.swipeactionview.SwipeGestureListener;

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -31,7 +31,25 @@
             android:id="@+id/swipe_right"
             style="@style/SwipeItem">
 
-            <ImageView style="@style/Icon" />
+            <me.thanel.swipeactionview.MultiSwipeActionView
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:orientation="horizontal">
+
+                <ImageView
+                    style="@style/Icon"
+                    android:contentDescription="i1" />
+
+                <View
+                    android:id="@+id/view"
+                    android:layout_width="1dp"
+                    android:layout_height="wrap_content"
+                    android:background="#C81111" />
+
+                <ImageView
+                    style="@style/Icon"
+                    android:contentDescription="i2" />
+            </me.thanel.swipeactionview.MultiSwipeActionView>
 
             <TextView
                 style="@style/Container"
@@ -42,9 +60,26 @@
             android:id="@+id/swipe_left"
             style="@style/SwipeItem">
 
-            <ImageView
-                style="@style/Icon"
-                android:layout_gravity="end|center_vertical" />
+            <me.thanel.swipeactionview.MultiSwipeActionView
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_gravity="end|center_vertical"
+                android:orientation="horizontal">
+
+                <ImageView
+                    style="@style/Icon"
+                    android:contentDescription="i3" />
+
+                <View
+                    android:layout_width="1dp"
+                    android:layout_height="wrap_content"
+                    android:background="#C81111" />
+
+                <ImageView
+                    style="@style/Icon"
+                    android:contentDescription="i4" />
+
+            </me.thanel.swipeactionview.MultiSwipeActionView>
 
             <TextView
                 style="@style/Container"

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -41,4 +41,5 @@
 
     <string name="swipe_left_complete">Swipe left complete</string>
     <string name="swipe_right_complete">Swipe right complete</string>
+    <string name="swiped_halfway">and only first icon</string>
 </resources>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -35,10 +35,10 @@
     </style>
 
     <style name="Icon">
-        <item name="android:layout_width">36dp</item>
+        <item name="android:layout_width">52dp</item>
         <item name="android:layout_height">36dp</item>
-        <item name="android:layout_marginLeft">8dp</item>
-        <item name="android:layout_marginRight">8dp</item>
+        <item name="android:paddingLeft">8dp</item>
+        <item name="android:paddingRight">8dp</item>
         <item name="android:layout_gravity">center_vertical</item>
         <item name="android:src">@mipmap/ic_launcher</item>
     </style>


### PR DESCRIPTION
![Screenshot_20231004_115140](https://github.com/Tunous/SwipeActionView/assets/25279821/34bf346a-d4a3-454f-80ae-6c7f7fce10bc)


This updates this library to a newer gradle version, aswell as java and kotlin.
This implements a specific container, that allows for two children to be treated as two distinct actions. 
Technically it allows for arbitrary amounts of elements, but only the first child (for the left actions) and the last child (for the right actions)  are used as a divider.

What works:
- Callback for halfway-action (left&right)

What doesn't work:
- "Sticky" halfway-point. (The main view always returns to the initial state)
- Maven publishing. The gradle-syntax changed, and i dont know how to test this

