### PR TITLE
Fix clicking buttons inside view doesn't always work

### DIFF
--- a/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
+++ b/library/src/main/kotlin/me/thanel/swipeactionview/SwipeActionView.kt
@@ -561,7 +561,7 @@ class SwipeActionView : FrameLayout {
 
             MotionEvent.ACTION_UP,
             MotionEvent.ACTION_CANCEL -> {
-                cancelDrag()
+                cancelDrag(false)
                 animateToOriginalPosition()
             }
         }


### PR DESCRIPTION
This change fixes the problem of clicking on any button inside the SwipeActionView. Even in the example that comes with the library, the "swipe_left" and "swipe_right" buttons are clicked 1-2 times out of 5.
I'm not sure if this solution is correct, but I haven't found any problems with this change yet.